### PR TITLE
Fixed a small bug in the sanitization example

### DIFF
--- a/docs/custom-validators-sanitizers.html
+++ b/docs/custom-validators-sanitizers.html
@@ -64,7 +64,7 @@ moment.</p>
 <pre><code class="hljs css languages- js"><span class="hljs-keyword">const</span> { sanitizeParam } = <span class="hljs-built_in">require</span>(<span class="hljs-string">'express-validator/filter'</span>);
 
 app.post(<span class="hljs-string">'/object/:id'</span>, sanitizeParam(<span class="hljs-string">'id'</span>).customSanitizer(<span class="hljs-function"><span class="hljs-params">value</span> =&gt;</span> {
-  <span class="hljs-keyword">return</span> ObjectId(id);
+  <span class="hljs-keyword">return</span> ObjectId(value);
 }), (req, res) =&gt; {
   <span class="hljs-comment">// Handle the request</span>
 });


### PR DESCRIPTION
`id` is the name of the URL param being sanitized... but the variable in the function is named `value`.