### PR TITLE
Fix bug in Getting Started section

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -79,13 +79,13 @@ app.post(<span class="hljs-string">'/user'</span>, (req, res) =&gt; {
 </code></pre>
 <p>Then, you'll want to make sure that you validate the input and report any errors before creating the user:</p>
 <pre><code class="hljs css language-js"><span class="hljs-comment">// ...rest of the initial code omitted for simplicity.</span>
-<span class="hljs-keyword">const</span> { check, validationResult } = <span class="hljs-built_in">require</span>(<span class="hljs-string">'express-validator'</span>);
+<span class="hljs-keyword">const</span> { body, validationResult } = <span class="hljs-built_in">require</span>(<span class="hljs-string">'express-validator'</span>);
 
 app.post(<span class="hljs-string">'/user'</span>, [
   <span class="hljs-comment">// username must be an email</span>
-  check(<span class="hljs-string">'username'</span>).isEmail(),
+  body(<span class="hljs-string">'username'</span>).isEmail(),
   <span class="hljs-comment">// password must be at least 5 chars long</span>
-  check(<span class="hljs-string">'password'</span>).isLength({ <span class="hljs-attr">min</span>: <span class="hljs-number">5</span> })
+  body(<span class="hljs-string">'password'</span>).isLength({ <span class="hljs-attr">min</span>: <span class="hljs-number">5</span> })
 ], (req, res) =&gt; {
   <span class="hljs-comment">// Finds the validation errors in this request and wraps them in an object with handy functions</span>
   <span class="hljs-keyword">const</span> errors = validationResult(req);


### PR DESCRIPTION
Without a fix, this server will validate a request that includes valid values transmitted via another vector (e.g. query string) but only use parameters from the request body. `check` will reject an invalid value for a parameter found on the body, but not an empty value. This is a bug, and repeating this mistake may create security vulnerabilities if programmers expect `req.body` to contain the parameters described by the array of validation middlewares preceding the request handler.

Example program using Getting Started code verbatim:

```javascript
const PORT = Number(process.env.PORT) || 8123

const User = {
  create(params) {
    console.log('mock: User.create called with', params)
    return Promise.resolve(params)
  }
}

const express = require('express');
const app = express();

app.use(express.json());
const { check, validationResult } = require('express-validator');

app.post('/user', [
  // username must be an email
  check('username').isEmail(),
  // password must be at least 5 chars long
  check('password').isLength({ min: 5 })
], (req, res) => {
  // Finds the validation errors in this request and wraps them in an object with handy functions
  const errors = validationResult(req);
  if (!errors.isEmpty()) {
    return res.status(422).json({ errors: errors.array() });
  }

  User.create({
    username: req.body.username,
    password: req.body.password
  }).then(user => res.json(user));
});

app.listen(PORT)
console.log('listening on port', PORT)
```

Example HTTP request using `curl`:

```bash
curl -X POST 'http://localhost:8123/user?username=foo@bar.com&password=secret' -H content-type:application/json -d '{}'
```

Example program output:

```
mock: User.create called with { username: undefined, password: undefined }
```